### PR TITLE
US-013: Consultas com JOIN

### DIFF
--- a/src/main/java/br/com/libraryjdbc/model/dao/CategoryDAO.java
+++ b/src/main/java/br/com/libraryjdbc/model/dao/CategoryDAO.java
@@ -1,6 +1,8 @@
 package br.com.libraryjdbc.model.dao;
 
 import java.util.List;
+import java.util.Map;
+
 import br.com.libraryjdbc.model.entities.Category;
 
 public interface CategoryDAO {
@@ -11,4 +13,6 @@ public interface CategoryDAO {
     Category findById(Long id);
     List<Category> findAll();
     Category findCategoryWithMostBooks();
+    Map<String, Integer> getCategoryBookCounts();
+
 }


### PR DESCRIPTION
### Descrição
Implementação de consultas avançadas com JOIN para relatórios de análise do acervo da biblioteca.

#### Principais Mudanças
- **Implementação getCategoryBookCounts()**: Adicionado método para contagem de livros por categoria usando INNER JOIN e GROUP BY.
- **Atualização CategoryDAO Interface**: Incluído novo método na interface para manter consistência do padrão DAO.
- **Validação de Funcionalidades Existentes**: Confirmadas implementações de categoria com mais livros (LEFT JOIN) e listagem de livros com dados de categoria (INNER JOIN).

### Lista de Verificação
- [X] Criado testes unitários.
- [X] A interface está responsiva e otimizada para diferentes tamanhos de tela (se aplicável).